### PR TITLE
adding more dynamic call for gcloud os

### DIFF
--- a/lesson-rancher/README.md
+++ b/lesson-rancher/README.md
@@ -3,7 +3,7 @@ In this lesson, we'll configure a virtual machine on Google Compute Engine to ru
 
 Run the following commands on Google Cloud Shell to create the Virtual Machine and firewall rule:
 ```
-gcloud beta compute instances create "rancher" --zone "us-east1-b" --machine-type "custom-1-8192-ext" --subnet "default" --maintenance-policy "MIGRATE" --no-service-account --no-scopes --min-cpu-platform "Automatic" --tags "rancher" --image "coreos-alpha-1576-1-0-v20171026" --image-project "coreos-cloud" --boot-disk-size "20" --boot-disk-type "pd-standard" --boot-disk-device-name "rancher"
+gcloud beta compute instances create "rancher" --zone "us-east1-b" --machine-type "custom-1-8192-ext" --subnet "default" --maintenance-policy "MIGRATE" --no-service-account --no-scopes --min-cpu-platform "Automatic" --tags "rancher" --image "$(gcloud beta compute images list --filter="family:coreos-alpha" --format="value(NAME)")" --image-project "coreos-cloud" --boot-disk-size "20" --boot-disk-type "pd-standard" --boot-disk-device-name "rancher"
 
 gcloud compute firewall-rules create rancher-test --direction=INGRESS --priority=1000 --network=default --action=ALLOW --rules="tcp:8000,tcp:8080,tcp:9000" --source-ranges=0.0.0.0/0 --target-tags=rancher
 ```


### PR DESCRIPTION
So the code that I added executes a gcloud command to get the current coreos-alpha image and pull only the name, and then will execute your original gcloud command. When I ran your command it errored out, because they have a new version (currently: `coreos-alpha-1897-0-0-v20180911`). So no the users will never have to face that problem again, because it finds the current coreos-alpha release and puts that as the name for the image.
i.e. this is how gcloud interprets it
```
gcloud beta compute instances create "rancher" --zone "us-east1-b" --machine-type "custom-1-8192-ext" --subnet "default" --maintenance-policy "MIGRATE" --no-service-account --no-scopes --min-cpu-platform "Automatic" --tags "rancher" --image "coreos-alpha-1897-0-0-v20180911" --image-project "coreos-cloud" --boot-disk-size "20" --boot-disk-type "pd-standard" --boot-disk-device-name "rancher"
```